### PR TITLE
Add optional "description" entry to font metadata

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -47,6 +47,7 @@ Example:
     [font]
     id = librepcb
     name = LibrePCB Font
+    description = This is the default font of LibrePCB.
     author = Max Müller <max@example.com>
     version = 1.0
     license = GPL-3.0+
@@ -183,6 +184,7 @@ TODO
 | --- | --- | --- | --- |
 | id | The identifier of this font. MUST only contain lowercase letters and minus characters. MUST start and end with a lowercase letter. | 1 | `librepcb` |
 | name | The name of this font. | 1 | `LibrePCB Font` |
+| description | Short description about this font (optional). | 0-1 | `This is an example.` |
 | version | The version of this font. SHOULD follow semantic versioning. | 1 | `0.4.1` |
 | author | The name of the copyright owner, in the format `Name <email>`. The email part is optional. | 0-n | `Max Müller <max@foo>` |
 | license | The SPDX identifier for the license of this font. Create multiple `License` entries if the font is published under multiple licenses. | 1-n | `Apache-2.0` |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -45,8 +45,8 @@ Example:
     format_version = 1.0
 
     [font]
-    name = LibrePCB Font
     id = librepcb
+    name = LibrePCB Font
     author = Max Müller <max@example.com>
     version = 1.0
     license = GPL-3.0+
@@ -181,8 +181,8 @@ TODO
 
 | Name | Description | Count | Example |
 | --- | --- | --- | --- |
-| name | The name of this font. | 1 | `LibrePCB Font` |
 | id | The identifier of this font. MUST only contain lowercase letters and minus characters. MUST start and end with a lowercase letter. | 1 | `librepcb` |
+| name | The name of this font. | 1 | `LibrePCB Font` |
 | version | The version of this font. SHOULD follow semantic versioning. | 1 | `0.4.1` |
 | author | The name of the copyright owner, in the format `Name <email>`. The email part is optional. | 0-n | `Max Müller <max@foo>` |
 | license | The SPDX identifier for the license of this font. Create multiple `License` entries if the font is published under multiple licenses. | 1-n | `Apache-2.0` |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -53,7 +53,8 @@ Example:
     license = GPL-3.0+
 
     [user]
-    comment = This is the official font used for LibrePCB projects.
+    last_modified = 2012-12-21
+    todo = Add U+03A9 (GREEK CAPITAL LETTER OMEGA)
 
     ---
 


### PR DESCRIPTION
A short description may be useful to describe where a font comes from, what it is intended for, or what project it belongs to, or whatever...

In addition I changed the order of `id` and `name` because for me it makes more sense to have the order `id` -> `name` -> `description`.